### PR TITLE
Ability to right click Teams/Players on Create Tournament Screen and update their Seed

### DIFF
--- a/TBG.UI/CreateTournament.xaml
+++ b/TBG.UI/CreateTournament.xaml
@@ -54,7 +54,19 @@
                 <TreeView Name="participantsTreeView" Width="220" Height="200">
                     <TreeView.Resources>
                         <HierarchicalDataTemplate DataType="{x:Type self:TournamentEntryView}" ItemsSource="{Binding Members}">
-                            <StackPanel Orientation="Horizontal">
+                            <StackPanel Orientation="Horizontal" >
+                                <StackPanel.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Header="Edit Seed" >
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="Seed: " VerticalAlignment="Center"/>
+                                                <TextBox x:Name="menuItem_Seed" Text="{Binding Seed, RelativeSource={RelativeSource AncestorType=self:TournamentEntryView}}" Width="60" 
+                                                         Height="30" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" KeyDown="menuItem_Seed_KeyDown"/>
+                                            </StackPanel>
+                                        </MenuItem>
+                                    </ContextMenu>
+                                </StackPanel.ContextMenu>
+                                
                                 <Image Source="Assets/group.png" Width="15" Height="15" Margin="3"/>
                                 <TextBlock x:Name="teamName" Text="{Binding TeamName}" VerticalAlignment="Center"/>
                                 <TextBlock Text=" [Count: " Foreground="Blue" VerticalAlignment="Center"/>
@@ -185,7 +197,7 @@
         </ComboBox>
 
         <!-- Create Tournament Button -->
-        <Button x:Name="createTournamentButton" Grid.Row="7" Grid.Column="2" Content="Create Tournment" Grid.ColumnSpan="2" HorizontalAlignment="Center" Width="150" Click="Create_Tournament_Click"/>
+        <Button x:Name="createTournamentButton" Grid.Row="7" Grid.Column="2" Content="Create Tournment" Grid.ColumnSpan="2" HorizontalAlignment="Center" Width="150" Click="Create_Tournament_Click" />
 
     </Grid>
 </Window>

--- a/TBG.UI/CreateTournament.xaml.cs
+++ b/TBG.UI/CreateTournament.xaml.cs
@@ -212,5 +212,24 @@ namespace TBG.UI
             }
             participantsTreeView.Items.Refresh();
         }
+        private void menuItem_Seed_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                object obj = sender;
+                TextBox box = (TextBox)sender;
+                var data = box.DataContext;
+
+                if (int.TryParse(box.Text, out int value))
+                {
+                    ((TournamentEntryView)data).Seed = value;
+
+                    teamsInTournament.Sort((x, y) => x.Seed.CompareTo(y.Seed));
+                    participantsTreeView.Items.Refresh();
+                }
+            }
+
+
+        }
     }
 }

--- a/TBG.UI/Models/TournamentEntryView.cs
+++ b/TBG.UI/Models/TournamentEntryView.cs
@@ -9,7 +9,7 @@ using TBG.Core.Interfaces;
 
 namespace TBG.UI.Models
 {
-    public class TournamentEntryView : DependencyObject, ITournamentEntry
+    public class TournamentEntryView : ITournamentEntry
     {
         public int TournamentEntryId { get; set; }
         public int TournamentId { get; set; }
@@ -21,6 +21,5 @@ namespace TBG.UI.Models
         {
             this.Members = new ObservableCollection<TeamMember>();
         }
-
     }
 }


### PR DESCRIPTION
Right clicking a team will bring up a contextMenu where you click on "edit seed" and type in your new seed value
![image](https://user-images.githubusercontent.com/44123272/67704387-0582c900-f983-11e9-9bf9-b83faec533f1.png)
