### PR TITLE
Feature seeding and dashboard filtering

### DIFF
--- a/TBG.Business/Tournaments/SingleEliminationTournament.cs
+++ b/TBG.Business/Tournaments/SingleEliminationTournament.cs
@@ -22,13 +22,18 @@ namespace TBG.Business.Tournaments
         public ITournament BuildTournament()
         {
             Participants = Participants.OrderByDescending(x => x.Seed).ToList();
-            List<ITournamentEntry> seededParticipants = new List<ITournamentEntry>();
-            for (int i = 0; i < Participants.Count / 2; i++)
+            bool useHiLoSeeding = Participants.Any(x => x.Seed > 0);
+            if (useHiLoSeeding)
             {
-                seededParticipants.Add(Participants[i]);
-                seededParticipants.Add(Participants[Participants.Count-1-i]);
+                List<ITournamentEntry> seededParticipants = new List<ITournamentEntry>();
+                for (int i = 0; i < Participants.Count / 2; i++)
+                {
+                    seededParticipants.Add(Participants[i]);
+                    seededParticipants.Add(Participants[Participants.Count - 1 - i]);
+                }
+                Participants = seededParticipants;
             }
-            Participants = seededParticipants;
+
 
             var teamQueue = BuildTeamQueue();
 

--- a/TBG.Core/Interfaces/IProvider.cs
+++ b/TBG.Core/Interfaces/IProvider.cs
@@ -39,5 +39,7 @@ namespace TBG.Core.Interfaces
         List<IRound> getRoundsByTournamentId(int tournamentId);
         IRoundMatchup getRoundMatchupByRoundIdAndMatchupNumber(IRoundMatchup roundMatchup);
         ITournament updateTournamentName(ITournament entry);
+        List<IMatchup> getAllMatchups();
+        IMatchup deleteMatchup(IMatchup matchup);
     }
 }

--- a/TBG.Data/Classes/DatabaseProvider.cs
+++ b/TBG.Data/Classes/DatabaseProvider.cs
@@ -313,9 +313,25 @@ namespace TBG.Data.Classes
 
             return matchup;
         }
+
+        public List<IMatchup> getAllMatchups()
+        {
+            List<IMatchup> matchup = MatchupsTable.GetAll(dbConn);
+            if (matchup == null) { return null; }
+
+            return matchup;
+        }
         public IMatchup createMatchup(IMatchup entry)
         {
             IMatchup matchup = MatchupsTable.Create(entry, dbConn);
+            if (matchup == null) return null;
+
+            return matchup;
+        }
+
+        public IMatchup deleteMatchup(IMatchup entry)
+        {
+            IMatchup matchup = MatchupsTable.Delete(entry, dbConn);
             if (matchup == null) return null;
 
             return matchup;

--- a/TBG.Data/SQL/Tables/MatchupEntries.sql
+++ b/TBG.Data/SQL/Tables/MatchupEntries.sql
@@ -5,7 +5,9 @@ CREATE TABLE MatchupEntries (
 	score						int(5) NOT NULL DEFAULT '0',
     PRIMARY KEY (matchup_entry_id),
     FOREIGN KEY (matchup_id)
-        REFERENCES Matchups (matchup_id),
+        REFERENCES Matchups (matchup_id)
+		ON DELETE CASCADE,
     FOREIGN KEY (tournament_entry_id)
         REFERENCES TournamentEntries (tournament_entry_id)
+		ON DELETE CASCADE
 );

--- a/TBG.Data/SQL/Tables/RoundMatchups.sql
+++ b/TBG.Data/SQL/Tables/RoundMatchups.sql
@@ -5,7 +5,9 @@ CREATE TABLE RoundMatchups (
 	matchup_number      int(11) NOT NULL,
     PRIMARY KEY (round_matchup_id),
     FOREIGN KEY (round_id)
-        REFERENCES Rounds (round_id),
+        REFERENCES Rounds (round_id)
+		ON DELETE CASCADE,
     FOREIGN KEY (matchup_id)
         REFERENCES Matchups (matchup_id)
+		ON DELETE CASCADE
 );

--- a/TBG.Data/SQL/Tables/Rounds.sql
+++ b/TBG.Data/SQL/Tables/Rounds.sql
@@ -5,4 +5,5 @@ CREATE TABLE Rounds (
     PRIMARY KEY (round_id),
     FOREIGN KEY (tournament_id)
         REFERENCES Tournaments (tournament_id)
+		ON DELETE CASCADE
 );

--- a/TBG.Data/SQL/Tables/TournamentEntries.sql
+++ b/TBG.Data/SQL/Tables/TournamentEntries.sql
@@ -5,7 +5,9 @@ CREATE TABLE TournamentEntries (
     seed                    decimal(11,10) NOT NULL,
     PRIMARY KEY (tournament_entry_id),
     FOREIGN KEY (tournament_id)
-        REFERENCES Tournaments (tournament_id),
+        REFERENCES Tournaments (tournament_id)
+		ON DELETE CASCADE,
     FOREIGN KEY (team_id)
         REFERENCES Teams (team_id)
+		ON DELETE CASCADE
 );

--- a/TBG.Data/Tables/MatchupsTable.cs
+++ b/TBG.Data/Tables/MatchupsTable.cs
@@ -34,6 +34,36 @@ namespace TBG.Data.Tables
             return null;
         }
 
+        public static IMatchup Delete(IMatchup entity, MySqlConnection dbConn)
+        {
+            string query = "DELETE FROM Matchups WHERE matchup_id = @id";
+            Dictionary<string, string> param = new Dictionary<string, string>();
+            param.Add("@id", entity.MatchupId.ToString());
+
+            var result = DatabaseHelper.GetNonQueryCount(query, dbConn, param);
+            if (result != 0)
+            {
+                return entity;
+            }
+
+            return null;
+        }
+
+        public static List<IMatchup> GetAll(MySqlConnection dbConn)
+        {
+            List<IMatchup> result = new List<IMatchup>();
+
+            string query = "SELECT * FROM Matchups";
+            using (var reader = DatabaseHelper.GetReader(query, dbConn))
+            {
+                while (reader.Read())
+                {
+                    result.Add(ConvertReader(reader));
+                }
+            }
+            return result;
+        }
+
         private static IMatchup ConvertReader(MySqlDataReader reader)
         {
             return new Matchup()

--- a/TBG.UI/Classes/Matchup.cs
+++ b/TBG.UI/Classes/Matchup.cs
@@ -12,5 +12,14 @@ namespace TBG.UI.Classes
         public int MatchupId { get; set; }
         public List<IMatchupEntry> Teams { get; set; }
         public IMatchup NextRound { get; set; }
+
+        public Matchup()
+        {
+        }
+
+        public Matchup(int matchupId)
+        {
+            MatchupId = matchupId;
+        }
     }
 }

--- a/TBG.UI/Classes/Tournament.cs
+++ b/TBG.UI/Classes/Tournament.cs
@@ -28,6 +28,11 @@ namespace TBG.UI.Classes
             Rounds = new List<IRound>();
         }
 
+        public Tournament(int tournamentId)
+        {
+            TournamentId = tournamentId;
+        }
+
         public ITournament BuildTournament()
         {
             throw new NotImplementedException();

--- a/TBG.UI/CreateTournament.xaml
+++ b/TBG.UI/CreateTournament.xaml
@@ -7,7 +7,7 @@
         xmlns:self="clr-namespace:TBG.UI.Classes"
         mc:Ignorable="d"
         Loaded="Window_Loaded"
-        Title="Tournament" Height="550" Width="820">
+        Title="Tournament" Height="550" Width="850">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="20" />
@@ -50,7 +50,7 @@
         <StackPanel Orientation="Vertical" Grid.Row="2" Grid.Column="2"  Margin="20,0,0,0" Grid.RowSpan="4" VerticalAlignment="Top">
             <TextBlock Text="Teams / Players" FontSize="18"/>
             <StackPanel Orientation="Horizontal">
-                <TreeView Name="participantsTreeView" Width="220" Height="200">
+                <TreeView Name="participantsTreeView" Width="250" Height="200">
                     <TreeView.Resources>
                         <HierarchicalDataTemplate DataType="{x:Type self:TournamentEntry}" ItemsSource="{Binding Members}">
                             <StackPanel Orientation="Horizontal">

--- a/TBG.UI/CreateTournament.xaml.cs
+++ b/TBG.UI/CreateTournament.xaml.cs
@@ -128,8 +128,9 @@ namespace TBG.UI
 
         private void Create_New_Team_Click(object sender, RoutedEventArgs e)
         {
-            TeamWindow teamWindow = new TeamWindow(this);
+            TeamWindow teamWindow = new TeamWindow(user);
             teamWindow.Show();
+            this.Close();
         }
 
         private void Create_New_Prize_Click(object sender, RoutedEventArgs e)

--- a/TBG.UI/CreateTournament.xaml.cs
+++ b/TBG.UI/CreateTournament.xaml.cs
@@ -44,6 +44,7 @@ namespace TBG.UI
             prizes = source.getAllPrizes();
             prizeComboBox.ItemsSource = prizes;
             prizePool = 0;
+            SeedToggle_Unchecked(sender, e);
         }
 
         private void SetEntryFee_Click(object sender, RoutedEventArgs e)
@@ -183,8 +184,10 @@ namespace TBG.UI
         {
             for (int i = 0; i < teamsInTournament.Count; i++)
             {
-                teamsInTournament[i].Seed = i + 1;
+                var team = teams.Where(x => x.TeamId == teamsInTournament[i].TeamId).First();
+                teamsInTournament[i].Seed = Math.Round(calculateWinPercentage(team.Wins, team.Losses), 3);
             }
+
             participantsTreeView.Items.Refresh();
         }
 
@@ -228,10 +231,14 @@ namespace TBG.UI
             teamsInTournament.ForEach(x => x.TournamentId = tournament.TournamentId);
             tournament.Participants = teamsInTournament;
 
-            foreach (var p in tournament.Participants)
+            bool useHiLoSeeding = tournament.Participants.Any(x => x.Seed > 0);
+            if (useHiLoSeeding)
             {
-                var team = tournament.Teams.Where(x => x.TeamId == p.TeamId).First();
-                p.Seed = calculateWinPercentage(team.Wins, team.Losses);
+                foreach (var p in tournament.Participants)
+                {
+                    var team = tournament.Teams.Where(x => x.TeamId == p.TeamId).First();
+                    p.Seed = calculateWinPercentage(team.Wins, team.Losses);
+                }
             }
 
 
@@ -242,6 +249,7 @@ namespace TBG.UI
                 source.setupTournamentData(newTournament);
                 TournamentViewUI viewUI = new TournamentViewUI(newTournament);
                 viewUI.Show();
+                this.Close();
             }
             else //error
             {

--- a/TBG.UI/Dashboard.xaml
+++ b/TBG.UI/Dashboard.xaml
@@ -54,9 +54,14 @@
             </StackPanel>
             <StackPanel Width="500" Margin="50,0,0,0">
                 <ListBox x:Name="tournamentList" Height="250" Width="400" Background="#FFFFFF" Margin="0,60,0,0" HorizontalAlignment="Center"/>
-                <Button Width="200" HorizontalAlignment="center" VerticalAlignment="Bottom" Margin="0,10,0,0" Content="Select Tournament" Click="Load_Tournament"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="center">
+                    <Button Width="150" HorizontalAlignment="center" VerticalAlignment="Bottom" Margin="0,10,10,0" Content="Select Tournament" Click="Load_Tournament"/>
+                    <Button Width="150" HorizontalAlignment="center" VerticalAlignment="Bottom" Margin="0,10,10,0" Content="Delete Tournament" Click="Delete_Tournament"/>
+                </StackPanel>
             </StackPanel>
         </StackPanel>
+        
+        <TextBlock x:Name="messageBox" HorizontalAlignment="Left" Margin="393,369,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Height="28" Width="307"/>
 
     </Grid>
 </Window>

--- a/TBG.UI/Dashboard.xaml
+++ b/TBG.UI/Dashboard.xaml
@@ -55,8 +55,8 @@
             <StackPanel Width="500" Margin="50,0,0,0">
                 <ListBox x:Name="tournamentList" Height="250" Width="400" Background="#FFFFFF" Margin="0,60,0,0" HorizontalAlignment="Center"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="center">
-                    <Button Width="150" HorizontalAlignment="center" VerticalAlignment="Bottom" Margin="0,10,10,0" Content="Select Tournament" Click="Load_Tournament"/>
-                    <Button Width="150" HorizontalAlignment="center" VerticalAlignment="Bottom" Margin="0,10,10,0" Content="Delete Tournament" Click="Delete_Tournament"/>
+                    <Button Width="150" HorizontalAlignment="center" VerticalAlignment="Bottom" Margin="0,10,50,0" Content="Select Tournament" Click="Load_Tournament"/>
+                    <Button Width="150" HorizontalAlignment="center" VerticalAlignment="Bottom" Margin="0,10,0,0" Content="Delete Tournament" Click="Delete_Tournament"/>
                 </StackPanel>
             </StackPanel>
         </StackPanel>

--- a/TBG.UI/Dashboard.xaml.cs
+++ b/TBG.UI/Dashboard.xaml.cs
@@ -126,7 +126,6 @@ namespace TBG.UI
 
             ITournament selectedTournament = source.getTournamentByName(allTournaments[tournamentList.SelectedIndex].TournamentName);
             ITournament tournament = source.deleteTournament(new Tournament(selectedTournament.TournamentId));
-            
 
             if (tournament != null)
             {

--- a/TBG.UI/Dashboard.xaml.cs
+++ b/TBG.UI/Dashboard.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using TBG.Core.Interfaces;
@@ -98,7 +99,7 @@ namespace TBG.UI
                         {
                             newTournament.Rounds[i].Pairings[j].Teams[0].Score = matchupEntries[0].Score;
                             newTournament.Rounds[i].Pairings[j].Teams[0].MatchupId = matchupEntries[0].MatchupId;
-                            newTournament.Rounds[i].Pairings[j].Teams[0].TournamentEntryId = matchupEntries[0].TournamentEntryId;
+                            newTournament.Rounds[i].Pairings[j].Teams[0].TheTeam.TournamentEntryId = matchupEntries[0].TournamentEntryId;
                         }
                         else if (matchupEntries.Count == 2)
                         {
@@ -106,8 +107,8 @@ namespace TBG.UI
                             newTournament.Rounds[i].Pairings[j].Teams[1].Score = matchupEntries[1].Score;
                             newTournament.Rounds[i].Pairings[j].Teams[0].MatchupId = matchupEntries[0].MatchupId;
                             newTournament.Rounds[i].Pairings[j].Teams[1].MatchupId = matchupEntries[1].MatchupId;
-                            newTournament.Rounds[i].Pairings[j].Teams[0].TournamentEntryId = matchupEntries[0].TournamentEntryId;
-                            newTournament.Rounds[i].Pairings[j].Teams[1].TournamentEntryId = matchupEntries[1].TournamentEntryId;
+                            newTournament.Rounds[i].Pairings[j].Teams[0].TheTeam.TournamentEntryId = matchupEntries[0].TournamentEntryId;
+                            newTournament.Rounds[i].Pairings[j].Teams[1].TheTeam.TournamentEntryId = matchupEntries[1].TournamentEntryId;
                         }
                     }
                 }
@@ -119,9 +120,13 @@ namespace TBG.UI
 
         public void Delete_Tournament(object sender, RoutedEventArgs e)
         {
-            if (tournamentList.SelectedIndex != -1)
+
+            Console.WriteLine("Temp: " + tournamentList.SelectedIndex);
+            Console.WriteLine(tournamentList.SelectedIndex == -1);
+            if (tournamentList.SelectedIndex == -1)
             {
                 messageBox.Text = "Please select a tournament";
+                return;
             }
 
             ITournament selectedTournament = source.getTournamentByName(allTournaments[tournamentList.SelectedIndex].TournamentName);
@@ -137,11 +142,34 @@ namespace TBG.UI
                         IMatchup currMatchup = source.deleteMatchup(new Matchup(matchup.MatchupId));
                     }
                 }
-                messageBox.Text = "Successfully deleted tournament";
-                allTournaments.RemoveAt(tournamentList.SelectedIndex);
+
                 tournamentList.Items.Clear();
-                tournamentList.ItemsSource = allTournaments;
+
+                allTournaments = source.getAllTournaments();
+                foreach (var t in allTournaments)
+                {
+                    var item = new TournamentListBoxItem(t.TournamentName);
+                    this.tournamentList.Items.Add(new ListBoxItem
+                    {
+                        Content = item.Name
+                    });
+                }
+
+                var tournamentTypes = source.getTournamentTypes();
+
+                foreach (var tournamentType in tournamentTypes)
+                {
+                    this.typeFilter.Items.Add(new ListBoxItem
+                    {
+                        Content = new Label
+                        {
+                            Content = tournamentType.TournamentTypeName
+                        }
+                    });
+                }
+
                 tournamentList.Items.Refresh();
+                messageBox.Text = "Successfully deleted tournament";
             }
             else
             {

--- a/TBG.UI/TeamWindow.xaml.cs
+++ b/TBG.UI/TeamWindow.xaml.cs
@@ -30,19 +30,19 @@ namespace TBG.UI
         private ITeamController teamController;
         private List<IPerson> personList;   //List of people in database
         private List<IPerson> selectedPersons; //List of people to create a new team with
-        private CreateTournament tournament;
+        private IUser user;
 
-        public TeamWindow(CreateTournament tournament)
+        public TeamWindow(IUser user)
         {
             InitializeComponent();
             source = ApplicationController.getProvider();
             personController = ApplicationController.getPersonController();
             teamController = ApplicationController.getTeamController();
-            this.tournament = tournament;
             personList = source.getPeople();
             personList.Sort((x,y) =>x.FirstName.CompareTo(y.FirstName));
             selectedPersons = new List<IPerson>();
             selectionListBox.ItemsSource = personList;
+            this.user = user;
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
@@ -69,8 +69,6 @@ namespace TBG.UI
                         selectedPersons.Add(p);
                     }
                 }
-                //if (selectedPersons != null && selectedPersons.Count > 0)
-                //selectedPersons.Sort();
                 selectionListBox.ItemsSource = selectedPersons;
             }
             else if (searchBox.Text == "")
@@ -176,33 +174,9 @@ namespace TBG.UI
             if (validate)
             {
                 ITeam createdTeam = source.createTeam(newTeam);
-
-                //Update Teams/Players on tournament Screen
-                List<ITournamentEntry> teams = tournament.teamsInTournament;
-                ITournamentEntry convertedTeam = convertToTeam(new List<ITeam>() { createdTeam })[0];
-                ObservableCollection<IPerson> teamMembers = new ObservableCollection<IPerson>();
-                foreach (ITeamMember teamMember in source.getTeamMembersByTeamId(createdTeam.TeamId))
-                {
-                    IPerson person = source.getPerson(teamMember.PersonId);
-                    teamMembers.Add(new Person()
-                    {
-                        PersonId = person.PersonId,
-                        FirstName = person.FirstName,
-                        LastName = person.LastName
-                    });
-                }
-
-                teams.Add(convertedTeam);
-                teams[teams.Count - 1].Members = teamMembers;
-                
-                tournament.participantsTreeView.ItemsSource = teams;
-                tournament.participantsTreeView.Items.Refresh();
-
-                //Update Select Teams
-                List<ITeam> allTeams = tournament.teams;
-                allTeams.Add(createdTeam);
-                tournament.selectionListBox.ItemsSource = allTeams;
-                tournament.selectionListBox.Items.Refresh();
+                CreateTournament createTournament = new CreateTournament(user);
+                createTournament.Show();
+                this.Close();
             }
 
         }

--- a/TBG.UI/TournamentViewUI.xaml.cs
+++ b/TBG.UI/TournamentViewUI.xaml.cs
@@ -127,6 +127,7 @@ namespace TBG.UI
             if (thisRound != null)
             {
                 List<IRoundMatchup> roundMatchups = source.getRoundMatchupsByRoundId(new RoundMatchup(thisRound.RoundId));
+                roundMatchups = roundMatchups.OrderBy(x => x.MatchupNumber).ToList();
 
                 foreach (IRoundMatchup roundMatchup in roundMatchups)
                 {
@@ -267,8 +268,8 @@ namespace TBG.UI
                 }
                 else
                 {
-                    tournament.Rounds[selectedRound + 1].Pairings[nextPairingNumber].Teams[teamIndex].TheTeam.TournamentEntryId = tournament.Rounds[selectedRound].Pairings[selectedPairing].Teams[teamIndex].TheTeam.TournamentEntryId;
-                    tournament.Rounds[selectedRound + 1].Pairings[nextPairingNumber].Teams[teamIndex].MatchupId = nextMatchupId;
+                    tournament.Rounds[selectedRound + 1].Pairings[nextPairingNumber].Teams[1].TheTeam.TournamentEntryId = tournament.Rounds[selectedRound].Pairings[selectedPairing].Teams[teamIndex].TheTeam.TournamentEntryId;
+                    tournament.Rounds[selectedRound + 1].Pairings[nextPairingNumber].Teams[1].MatchupId = nextMatchupId;
                 }
 
 

--- a/TBG.UnitTests/LoginUnitTests.cs
+++ b/TBG.UnitTests/LoginUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TBG.Business;
+using TBG.Business.Controllers;
 using TBG.Core.Interfaces;
 using TBG.Data.Classes;
 using TBG.Data.Entities;

--- a/TBG.UnitTests/PersonUnitTests.cs
+++ b/TBG.UnitTests/PersonUnitTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TBG.Business;
+using TBG.Business.Controllers;
+using TBG.Business.Models;
 using TBG.Core.Interfaces;
 using TBG.Data.Classes;
 

--- a/TBG.UnitTests/PrizeUnitTests.cs
+++ b/TBG.UnitTests/PrizeUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TBG.Business;
+using TBG.Business.Controllers;
 using TBG.Core.Interfaces;
 
 namespace TBG.UnitTests

--- a/TBG.UnitTests/TeamUnitTests.cs
+++ b/TBG.UnitTests/TeamUnitTests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TBG.Business;
+using TBG.Business.Controllers;
+using TBG.Business.Models;
 using TBG.Core.Interfaces;
 using TBG.Data.Classes;
 

--- a/TBG.UnitTests/TournamentUnitTests.cs
+++ b/TBG.UnitTests/TournamentUnitTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TBG.Business;
+using TBG.Business.Controllers;
 
 namespace TBG.UnitTests
 {


### PR DESCRIPTION
What I did:
- I changed MatchupEntries, RoundMatchups, Rounds, and TournamentEntries to On Delete Cascade
- From the first point, you can delete Tournaments now in the dashboard and it deletes from the related tables automatically
- Creating a team in the TeamWindow no longer adds that team to the CreateTournament listbox like it did before
-I added references in every UnitTest because it broke from the last merge
-I added Seeding functionality so after adding teams to a tournament click "enable seeding" and it will display in the view and it should order them correctly in the Tournament viewer.

You should see this on the Dashboard now:
![image](https://user-images.githubusercontent.com/44123272/69490234-4ff44a00-0e4a-11ea-9b56-809daaad463e.png)
